### PR TITLE
feat: add logcat text coloration

### DIFF
--- a/src/main/resources/Gradianto_Nature_Green.xml
+++ b/src/main/resources/Gradianto_Nature_Green.xml
@@ -338,6 +338,31 @@
         <option name="FOREGROUND" value="5686aa" />
       </value>
     </option>
+    <option name="LOGCAT_ASSERT_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="CC666E"/>
+      </value>
+    </option>
+    <option name="LOGCAT_DEBUG_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="299999"/>
+      </value>
+    </option>
+    <option name="LOGCAT_ERROR_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="CC666E"/>
+      </value>
+    </option>
+    <option name="LOGCAT_INFO_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="ABC023"/>
+      </value>
+    </option>
+    <option name="LOGCAT_VERBOSE_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="5394EC"/>
+      </value>
+    </option>
     <option name="MARKED_FOR_REMOVAL_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="bc3c4f" />

--- a/src/main/resources/Gradianto_dark_fuchsia.xml
+++ b/src/main/resources/Gradianto_dark_fuchsia.xml
@@ -338,6 +338,31 @@
         <option name="FOREGROUND" value="5686aa" />
       </value>
     </option>
+    <option name="LOGCAT_ASSERT_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="CC666E"/>
+      </value>
+    </option>
+    <option name="LOGCAT_DEBUG_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="299999"/>
+      </value>
+    </option>
+    <option name="LOGCAT_ERROR_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="CC666E"/>
+      </value>
+    </option>
+    <option name="LOGCAT_INFO_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="ABC023"/>
+      </value>
+    </option>
+    <option name="LOGCAT_VERBOSE_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="5394EC"/>
+      </value>
+    </option>
     <option name="MATCHED_BRACE_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="bc47b2" />

--- a/src/main/resources/Gradianto_deep_ocean.xml
+++ b/src/main/resources/Gradianto_deep_ocean.xml
@@ -223,6 +223,31 @@
         <option name="BACKGROUND" value="173368" />
       </value>
     </option>
+    <option name="LOGCAT_ASSERT_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="CC666E"/>
+      </value>
+    </option>
+    <option name="LOGCAT_DEBUG_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="299999"/>
+      </value>
+    </option>
+    <option name="LOGCAT_ERROR_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="CC666E"/>
+      </value>
+    </option>
+    <option name="LOGCAT_INFO_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="ABC023"/>
+      </value>
+    </option>
+    <option name="LOGCAT_VERBOSE_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="5394EC"/>
+      </value>
+    </option>
     <option name="NOT_USED_ELEMENT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="507a95" />

--- a/src/main/resources/Gradianto_midnight_blue.xml
+++ b/src/main/resources/Gradianto_midnight_blue.xml
@@ -253,6 +253,31 @@
         <option name="BACKGROUND" value="2a2c5e" />
       </value>
     </option>
+    <option name="LOGCAT_ASSERT_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="CC666E"/>
+      </value>
+    </option>
+    <option name="LOGCAT_DEBUG_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="299999"/>
+      </value>
+    </option>
+    <option name="LOGCAT_ERROR_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="CC666E"/>
+      </value>
+    </option>
+    <option name="LOGCAT_INFO_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="ABC023"/>
+      </value>
+    </option>
+    <option name="LOGCAT_VERBOSE_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="5394EC"/>
+      </value>
+    </option>
     <option name="NOT_USED_ELEMENT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="a09fb1" />


### PR DESCRIPTION
logcat text was not set
set them using Gradianto default log colors

Hello !
I'm using Gradianto theme in android studio and IntelliJ. 
Doing some android development, and logcat logs was white, 
so I added logcat coloration !

The colors are the ones used in Gradianto logs,
just copy and paste hex colors in logcat settings :)